### PR TITLE
1차 스프린트에서 설계한 테이블을 모두 엔티티와 매핑한다

### DIFF
--- a/src/main/java/alex/toy/nmj/NmjApplication.java
+++ b/src/main/java/alex/toy/nmj/NmjApplication.java
@@ -2,8 +2,10 @@ package alex.toy.nmj;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class NmjApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/alex/toy/nmj/common/domain/Address.java
+++ b/src/main/java/alex/toy/nmj/common/domain/Address.java
@@ -1,0 +1,47 @@
+package alex.toy.nmj.common.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.util.Objects;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Address {
+
+    @Column(name = "road_name_address",
+            nullable = false,
+            length = 200)
+    private String roadName;
+
+    @Column(name = "detail_address",
+            nullable = false,
+            length = 200)
+    private String detail;
+
+    public Address(final String roadName, final String detail) {
+        this.roadName = roadName;
+        this.detail = detail;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Address that = (Address) o;
+        return Objects.equals(getRoadName(), that.getRoadName()) && Objects.equals(getDetail(), that.getDetail());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getRoadName(), getDetail());
+    }
+}

--- a/src/main/java/alex/toy/nmj/common/domain/Address.java
+++ b/src/main/java/alex/toy/nmj/common/domain/Address.java
@@ -13,14 +13,10 @@ import java.util.Objects;
 @Getter
 public class Address {
 
-    @Column(name = "road_name_address",
-            nullable = false,
-            length = 200)
+    @Column(name = "road_name_address", nullable = false, length = 200)
     private String roadName;
 
-    @Column(name = "detail_address",
-            nullable = false,
-            length = 200)
+    @Column(name = "detail_address", nullable = false, length = 200)
     private String detail;
 
     public Address(final String roadName, final String detail) {

--- a/src/main/java/alex/toy/nmj/common/domain/BaseEntity.java
+++ b/src/main/java/alex/toy/nmj/common/domain/BaseEntity.java
@@ -13,16 +13,13 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 @Getter
-public class BaseTimeEntity {
+public class BaseEntity {
 
     @CreatedDate
-    @Column(name = "created_date",
-            nullable = false,
-            updatable = false)
+    @Column(name = "created_date", nullable = false, updatable = false)
     private LocalDateTime createdDate;
 
     @LastModifiedDate
-    @Column(name = "last_modified_date",
-            nullable = false)
-    private LocalDateTime lastModifiedDate;
+    @Column(name = "last_modified_date", nullable = false)
+    private LocalDateTime modifiedDate;
 }

--- a/src/main/java/alex/toy/nmj/common/domain/BaseTimeEntity.java
+++ b/src/main/java/alex/toy/nmj/common/domain/BaseTimeEntity.java
@@ -1,0 +1,28 @@
+package alex.toy.nmj.common.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_date",
+            nullable = false,
+            updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    @Column(name = "last_modified_date",
+            nullable = false)
+    private LocalDateTime lastModifiedDate;
+}

--- a/src/main/java/alex/toy/nmj/common/domain/LatLng.java
+++ b/src/main/java/alex/toy/nmj/common/domain/LatLng.java
@@ -1,0 +1,43 @@
+package alex.toy.nmj.common.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.util.Objects;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class LatLng {
+
+    @Column(nullable = false)
+    private double lat;
+
+    @Column(nullable = false)
+    private double lng;
+
+    public LatLng(final double lat, final double lng) {
+        this.lat = lat;
+        this.lng = lng;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LatLng latLng = (LatLng) o;
+        return Double.compare(latLng.getLat(), getLat()) == 0 && Double.compare(latLng.getLng(), getLng()) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getLat(), getLng());
+    }
+}

--- a/src/main/java/alex/toy/nmj/common/domain/StartEndTime.java
+++ b/src/main/java/alex/toy/nmj/common/domain/StartEndTime.java
@@ -1,0 +1,39 @@
+package alex.toy.nmj.common.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class StartEndTime {
+
+    @Column(name = "start_date")
+    private LocalDateTime startDate;
+
+    @Column(name = "end_date")
+    private LocalDateTime endDate;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        StartEndTime that = (StartEndTime) o;
+        return Objects.equals(getStartDate(), that.getStartDate()) && Objects.equals(getEndDate(), that.getEndDate());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getStartDate(), getEndDate());
+    }
+}

--- a/src/main/java/alex/toy/nmj/common/domain/StartEndTime.java
+++ b/src/main/java/alex/toy/nmj/common/domain/StartEndTime.java
@@ -14,10 +14,10 @@ import java.util.Objects;
 @Getter
 public class StartEndTime {
 
-    @Column(name = "start_date")
+    @Column(nullable = false)
     private LocalDateTime startDate;
 
-    @Column(name = "end_date")
+    @Column(nullable = false)
     private LocalDateTime endDate;
 
     @Override

--- a/src/main/java/alex/toy/nmj/csreqeust/domain/CsRequest.java
+++ b/src/main/java/alex/toy/nmj/csreqeust/domain/CsRequest.java
@@ -1,0 +1,68 @@
+package alex.toy.nmj.csreqeust.domain;
+
+import alex.toy.nmj.common.domain.BaseTimeEntity;
+import alex.toy.nmj.review.domain.Review;
+import alex.toy.nmj.store.domain.Store;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import static javax.persistence.EnumType.STRING;
+import static javax.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "NMJ_CS_REQUEST")
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class CsRequest extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "cs_id")
+    private Long id;
+
+    @Enumerated(STRING)
+    @Column(name = "cs_type",
+            nullable = false,
+            length = 45)
+    private CsType type;
+
+    @Column(name = "cs_description",
+            columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(STRING)
+    @Column(name = "cs_status",
+            nullable = false,
+            length = 45)
+    private CsStatus status;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "review_id")
+    private Review review;
+
+    @Builder
+    private CsRequest(final Long id, final CsType type, final String description,
+                      final CsStatus status, final Store store, final Review review) {
+        this.id = id;
+        this.type = type;
+        this.description = description;
+        this.status = status;
+        this.store = store;
+        this.review = review;
+    }
+}

--- a/src/main/java/alex/toy/nmj/csreqeust/domain/CsRequest.java
+++ b/src/main/java/alex/toy/nmj/csreqeust/domain/CsRequest.java
@@ -1,6 +1,6 @@
 package alex.toy.nmj.csreqeust.domain;
 
-import alex.toy.nmj.common.domain.BaseTimeEntity;
+import alex.toy.nmj.common.domain.BaseEntity;
 import alex.toy.nmj.review.domain.Review;
 import alex.toy.nmj.store.domain.Store;
 import lombok.Builder;
@@ -24,7 +24,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "NMJ_CS_REQUEST")
 @NoArgsConstructor(access = PROTECTED)
 @Getter
-public class CsRequest extends BaseTimeEntity {
+public class CsRequest extends BaseEntity {
 
     @Id
     @GeneratedValue
@@ -32,19 +32,14 @@ public class CsRequest extends BaseTimeEntity {
     private Long id;
 
     @Enumerated(STRING)
-    @Column(name = "cs_type",
-            nullable = false,
-            length = 45)
+    @Column(nullable = false, length = 20)
     private CsType type;
 
-    @Column(name = "cs_description",
-            columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT")
     private String description;
 
     @Enumerated(STRING)
-    @Column(name = "cs_status",
-            nullable = false,
-            length = 45)
+    @Column(nullable = false, length = 20)
     private CsStatus status;
 
     @OneToOne(fetch = LAZY)

--- a/src/main/java/alex/toy/nmj/csreqeust/domain/CsStatus.java
+++ b/src/main/java/alex/toy/nmj/csreqeust/domain/CsStatus.java
@@ -1,0 +1,5 @@
+package alex.toy.nmj.csreqeust.domain;
+
+public enum CsStatus {
+    BEFORE, SOLVED, IGNORE,
+}

--- a/src/main/java/alex/toy/nmj/csreqeust/domain/CsType.java
+++ b/src/main/java/alex/toy/nmj/csreqeust/domain/CsType.java
@@ -1,0 +1,5 @@
+package alex.toy.nmj.csreqeust.domain;
+
+public enum CsType {
+    REGISTER, UPDATE, REVIEW,
+}

--- a/src/main/java/alex/toy/nmj/member/domain/Member.java
+++ b/src/main/java/alex/toy/nmj/member/domain/Member.java
@@ -1,6 +1,6 @@
 package alex.toy.nmj.member.domain;
 
-import alex.toy.nmj.common.domain.BaseTimeEntity;
+import alex.toy.nmj.common.domain.BaseEntity;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,37 +19,27 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "NMJ_MEMBER")
 @NoArgsConstructor(access = PROTECTED)
 @Getter
-public class Member extends BaseTimeEntity {
+public class Member extends BaseEntity {
 
     @Id
     @GeneratedValue
     @Column(name = "member_id")
     private Long id;
 
-    @Column(name = "member_email",
-            nullable = false,
-            length = 100)
+    @Column(nullable = false, length = 100)
     private String email;
 
-    @Column(name = "member_password",
-            nullable = false,
-            length = 70)
+    @Column(nullable = false, length = 70)
     private String password;
 
-    @Column(name = "member_name",
-            nullable = false,
-            length = 45)
+    @Column(nullable = false, length = 45)
     private String name;
 
-    @Column(name = "member_phone",
-            nullable = false,
-            length = 20)
+    @Column(nullable = false, length = 13)
     private String phone;
 
     @Enumerated(STRING)
-    @Column(name = "member_type",
-            nullable = false,
-            length = 30)
+    @Column(nullable = false, length = 15)
     private MemberType type;
 
     @Builder

--- a/src/main/java/alex/toy/nmj/member/domain/Member.java
+++ b/src/main/java/alex/toy/nmj/member/domain/Member.java
@@ -1,0 +1,65 @@
+package alex.toy.nmj.member.domain;
+
+import alex.toy.nmj.common.domain.BaseTimeEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import static javax.persistence.EnumType.STRING;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "NMJ_MEMBER")
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class Member extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "member_id")
+    private Long id;
+
+    @Column(name = "member_email",
+            nullable = false,
+            length = 100)
+    private String email;
+
+    @Column(name = "member_password",
+            nullable = false,
+            length = 70)
+    private String password;
+
+    @Column(name = "member_name",
+            nullable = false,
+            length = 45)
+    private String name;
+
+    @Column(name = "member_phone",
+            nullable = false,
+            length = 20)
+    private String phone;
+
+    @Enumerated(STRING)
+    @Column(name = "member_type",
+            nullable = false,
+            length = 30)
+    private MemberType type;
+
+    @Builder
+    private Member(final Long id, final String email, final String password,
+                   final String name, final String phone, final MemberType type) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.phone = phone;
+        this.type = type;
+    }
+}

--- a/src/main/java/alex/toy/nmj/member/domain/MemberLike.java
+++ b/src/main/java/alex/toy/nmj/member/domain/MemberLike.java
@@ -1,0 +1,37 @@
+package alex.toy.nmj.member.domain;
+
+import alex.toy.nmj.store.domain.Store;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import static javax.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "NMJ_MEMBER_LIKE")
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class MemberLike {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "like_id")
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+}

--- a/src/main/java/alex/toy/nmj/member/domain/MemberType.java
+++ b/src/main/java/alex/toy/nmj/member/domain/MemberType.java
@@ -1,0 +1,5 @@
+package alex.toy.nmj.member.domain;
+
+public enum MemberType {
+    USER, STORE, ADMIN, DELETED, WAIT,
+}

--- a/src/main/java/alex/toy/nmj/reserve/domain/Reserve.java
+++ b/src/main/java/alex/toy/nmj/reserve/domain/Reserve.java
@@ -1,0 +1,69 @@
+package alex.toy.nmj.reserve.domain;
+
+import alex.toy.nmj.common.domain.BaseTimeEntity;
+import alex.toy.nmj.common.domain.StartEndTime;
+import alex.toy.nmj.store.domain.Store;
+import alex.toy.nmj.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import static javax.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "NMJ_RESERVE")
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class Reserve extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "reserve_id")
+    private Long id;
+
+    @Column(name = "reserve_people_count",
+            nullable = false)
+    private int peopleCount;
+
+    @Column(name = "reserve_approve_status",
+            nullable = false)
+    @ColumnDefault("false")
+    private boolean approveStatus;
+
+    @Embedded
+    @AttributeOverride(name = "startDate",
+            column = @Column(name = "reserve_start_date", nullable = false))
+    @AttributeOverride(name = "endDate",
+            column = @Column(name = "reserve_end_date", nullable = false))
+    private StartEndTime startEndTime;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @Builder
+    private Reserve(final Long id, final int peopleCount, final StartEndTime startEndTime,
+                    final Member member, final Store store) {
+        this.id = id;
+        this.peopleCount = peopleCount;
+        this.startEndTime = startEndTime;
+        this.member = member;
+        this.store = store;
+    }
+}

--- a/src/main/java/alex/toy/nmj/reserve/domain/Reserve.java
+++ b/src/main/java/alex/toy/nmj/reserve/domain/Reserve.java
@@ -1,6 +1,6 @@
 package alex.toy.nmj.reserve.domain;
 
-import alex.toy.nmj.common.domain.BaseTimeEntity;
+import alex.toy.nmj.common.domain.BaseEntity;
 import alex.toy.nmj.common.domain.StartEndTime;
 import alex.toy.nmj.store.domain.Store;
 import alex.toy.nmj.member.domain.Member;
@@ -26,27 +26,21 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "NMJ_RESERVE")
 @NoArgsConstructor(access = PROTECTED)
 @Getter
-public class Reserve extends BaseTimeEntity {
+public class Reserve extends BaseEntity {
 
     @Id
     @GeneratedValue
     @Column(name = "reserve_id")
     private Long id;
 
-    @Column(name = "reserve_people_count",
-            nullable = false)
+    @Column(nullable = false)
     private int peopleCount;
 
-    @Column(name = "reserve_approve_status",
-            nullable = false)
+    @Column(nullable = false)
     @ColumnDefault("false")
     private boolean approveStatus;
 
     @Embedded
-    @AttributeOverride(name = "startDate",
-            column = @Column(name = "reserve_start_date", nullable = false))
-    @AttributeOverride(name = "endDate",
-            column = @Column(name = "reserve_end_date", nullable = false))
     private StartEndTime startEndTime;
 
     @ManyToOne(fetch = LAZY)
@@ -65,5 +59,6 @@ public class Reserve extends BaseTimeEntity {
         this.startEndTime = startEndTime;
         this.member = member;
         this.store = store;
+        this.approveStatus = false;
     }
 }

--- a/src/main/java/alex/toy/nmj/review/domain/Review.java
+++ b/src/main/java/alex/toy/nmj/review/domain/Review.java
@@ -1,0 +1,68 @@
+package alex.toy.nmj.review.domain;
+
+import alex.toy.nmj.common.domain.BaseTimeEntity;
+import alex.toy.nmj.store.domain.Store;
+import alex.toy.nmj.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import static javax.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "NMJ_REVIEW")
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class Review extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "review_id")
+    private Long id;
+
+    @Column(name = "review_rate",
+            nullable = false)
+    private double rate;
+
+    @Column(name = "review_description",
+            columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "review_report_status",
+            nullable = false)
+    @ColumnDefault("false")
+    private boolean reportStatus;
+
+    @Column(name = "review_star_count",
+            nullable = false)
+    @ColumnDefault("0")
+    private int starCount;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+    @Builder
+    private Review(final Long id, final double rate, final String description,
+                   final Member member, final Store store) {
+        this.id = id;
+        this.rate = rate;
+        this.description = description;
+        this.member = member;
+        this.store = store;
+    }
+}

--- a/src/main/java/alex/toy/nmj/review/domain/Review.java
+++ b/src/main/java/alex/toy/nmj/review/domain/Review.java
@@ -1,6 +1,6 @@
 package alex.toy.nmj.review.domain;
 
-import alex.toy.nmj.common.domain.BaseTimeEntity;
+import alex.toy.nmj.common.domain.BaseEntity;
 import alex.toy.nmj.store.domain.Store;
 import alex.toy.nmj.member.domain.Member;
 import lombok.Builder;
@@ -23,28 +23,24 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "NMJ_REVIEW")
 @NoArgsConstructor(access = PROTECTED)
 @Getter
-public class Review extends BaseTimeEntity {
+public class Review extends BaseEntity {
 
     @Id
     @GeneratedValue
     @Column(name = "review_id")
     private Long id;
 
-    @Column(name = "review_rate",
-            nullable = false)
+    @Column(nullable = false)
     private double rate;
 
-    @Column(name = "review_description",
-            columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT")
     private String description;
 
-    @Column(name = "review_report_status",
-            nullable = false)
+    @Column(nullable = false)
     @ColumnDefault("false")
     private boolean reportStatus;
 
-    @Column(name = "review_star_count",
-            nullable = false)
+    @Column(nullable = false)
     @ColumnDefault("0")
     private int starCount;
 
@@ -64,5 +60,7 @@ public class Review extends BaseTimeEntity {
         this.description = description;
         this.member = member;
         this.store = store;
+        this.reportStatus = false;
+        this.starCount = 0;
     }
 }

--- a/src/main/java/alex/toy/nmj/store/domain/Store.java
+++ b/src/main/java/alex/toy/nmj/store/domain/Store.java
@@ -1,0 +1,96 @@
+package alex.toy.nmj.store.domain;
+
+import alex.toy.nmj.common.domain.Address;
+import alex.toy.nmj.common.domain.BaseTimeEntity;
+import alex.toy.nmj.common.domain.LatLng;
+import alex.toy.nmj.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import static javax.persistence.EnumType.STRING;
+import static javax.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "NMJ_STORE")
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class Store extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "store_id")
+    private Long id;
+
+    @Column(name = "store_name",
+            nullable = false,
+            length = 45)
+    private String name;
+
+    @Column(name = "store_phone",
+            nullable = false,
+            length = 45)
+    private String phone;
+
+    @Column(name = "store_hours",
+            nullable = false,
+            length = 50)
+    private String hours;
+
+    @Column(name = "store_description",
+            columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(STRING)
+    @Column(name = "store_type",
+            nullable = false,
+            length = 30)
+    private StoreType type;
+
+    @Column(name = "store_ratings",
+            nullable = false)
+    @ColumnDefault("0.0")
+    private double ratings;
+
+    @Column(name = "store_rate_count",
+            nullable = false)
+    @ColumnDefault("0")
+    private int rateCount;
+
+    @Embedded
+    private Address address;
+
+    @Embedded
+    private LatLng latLng;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    private Store(final Long id, final String name, final String phone,
+                  final String hours, final String description, final StoreType type,
+                  final Address address, final LatLng latLng, final Member member) {
+        this.id = id;
+        this.name = name;
+        this.phone = phone;
+        this.hours = hours;
+        this.description = description;
+        this.type = type;
+        this.address = address;
+        this.latLng = latLng;
+        this.member = member;
+    }
+}

--- a/src/main/java/alex/toy/nmj/store/domain/Store.java
+++ b/src/main/java/alex/toy/nmj/store/domain/Store.java
@@ -1,7 +1,7 @@
 package alex.toy.nmj.store.domain;
 
 import alex.toy.nmj.common.domain.Address;
-import alex.toy.nmj.common.domain.BaseTimeEntity;
+import alex.toy.nmj.common.domain.BaseEntity;
 import alex.toy.nmj.common.domain.LatLng;
 import alex.toy.nmj.member.domain.Member;
 import lombok.Builder;
@@ -27,47 +27,38 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "NMJ_STORE")
 @NoArgsConstructor(access = PROTECTED)
 @Getter
-public class Store extends BaseTimeEntity {
+public class Store extends BaseEntity {
 
     @Id
     @GeneratedValue
     @Column(name = "store_id")
     private Long id;
 
-    @Column(name = "store_name",
-            nullable = false,
-            length = 45)
+    @Column(nullable = false, length = 45)
     private String name;
 
-    @Column(name = "store_phone",
-            nullable = false,
-            length = 45)
+    @Column(nullable = false, length = 13)
     private String phone;
 
-    @Column(name = "store_hours",
-            nullable = false,
-            length = 50)
-    private String hours;
+    @Column(nullable = false, length = 11)
+    private String businessHours;
 
-    @Column(name = "store_description",
-            columnDefinition = "TEXT")
+    @Column(columnDefinition = "TEXT")
     private String description;
 
     @Enumerated(STRING)
-    @Column(name = "store_type",
-            nullable = false,
-            length = 30)
+    @Column(nullable = false, length = 10)
     private StoreType type;
 
-    @Column(name = "store_ratings",
-            nullable = false)
+    @Column(nullable = false)
     @ColumnDefault("0.0")
     private double ratings;
 
-    @Column(name = "store_rate_count",
-            nullable = false)
+    @Column(nullable = false)
     @ColumnDefault("0")
     private int rateCount;
+
+    private Long mainImageId;
 
     @Embedded
     private Address address;
@@ -81,16 +72,19 @@ public class Store extends BaseTimeEntity {
 
     @Builder
     private Store(final Long id, final String name, final String phone,
-                  final String hours, final String description, final StoreType type,
-                  final Address address, final LatLng latLng, final Member member) {
+                  final String businessHours, final String description, final StoreType type,
+                  final Long mainImageId, final Address address, final LatLng latLng, final Member member) {
         this.id = id;
         this.name = name;
         this.phone = phone;
-        this.hours = hours;
+        this.businessHours = businessHours;
         this.description = description;
         this.type = type;
+        this.mainImageId = mainImageId;
         this.address = address;
         this.latLng = latLng;
         this.member = member;
+        this.rateCount = 0;
+        this.ratings = 0.0;
     }
 }

--- a/src/main/java/alex/toy/nmj/store/domain/StoreImage.java
+++ b/src/main/java/alex/toy/nmj/store/domain/StoreImage.java
@@ -1,0 +1,47 @@
+package alex.toy.nmj.store.domain;
+
+import alex.toy.nmj.common.domain.BaseTimeEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import static javax.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Table(name = "NMJ_STORE_IMAGE")
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+public class StoreImage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue
+    @Column(name = "image_id")
+    private Long id;
+
+    @Column(name = "image_name",
+            length = 50)
+    private String name;
+
+    @Column(name = "image_path",
+            nullable = false,
+            length = 200)
+    private String path;
+
+    @Column(name = "image_representative_status",
+            nullable = false)
+    @ColumnDefault("false")
+    private boolean representativeStatus;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "store_id")
+    private Store store;
+}

--- a/src/main/java/alex/toy/nmj/store/domain/StoreImage.java
+++ b/src/main/java/alex/toy/nmj/store/domain/StoreImage.java
@@ -1,6 +1,7 @@
 package alex.toy.nmj.store.domain;
 
-import alex.toy.nmj.common.domain.BaseTimeEntity;
+import alex.toy.nmj.common.domain.BaseEntity;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
@@ -20,28 +21,29 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "NMJ_STORE_IMAGE")
 @NoArgsConstructor(access = PROTECTED)
 @Getter
-public class StoreImage extends BaseTimeEntity {
+public class StoreImage extends BaseEntity {
 
     @Id
     @GeneratedValue
     @Column(name = "image_id")
     private Long id;
 
-    @Column(name = "image_name",
-            length = 50)
+    @Column(length = 50)
     private String name;
 
-    @Column(name = "image_path",
-            nullable = false,
-            length = 200)
+    @Column(nullable = false, length = 200)
     private String path;
-
-    @Column(name = "image_representative_status",
-            nullable = false)
-    @ColumnDefault("false")
-    private boolean representativeStatus;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "store_id")
     private Store store;
+
+    @Builder
+    private StoreImage(final Long id, final String name,
+                       final String path, final Store store) {
+        this.id = id;
+        this.name = name;
+        this.path = path;
+        this.store = store;
+    }
 }

--- a/src/main/java/alex/toy/nmj/store/domain/StoreType.java
+++ b/src/main/java/alex/toy/nmj/store/domain/StoreType.java
@@ -1,0 +1,5 @@
+package alex.toy.nmj.store.domain;
+
+public enum StoreType {
+    NOL, MUK, JA
+}


### PR DESCRIPTION
## 개요

- close: #4 

## 작업 요약

- 1차 스프린트에서 설계한 테이블을 모두 엔티티 객체와 매핑한다

## 작업 내용

> (체크 박스를 모두 선택해야 merge가 활성화 됩니다.)

- [x]  회원 테이블
- [x]  회원 찜 정보 테이블
- [x] 매장 정보 테이블
- [x] 매장 사진 정보 테이블
- [x] 예약 정보 테이블
- [x] 리뷰 정보 테이블
- [x] CS 요청 내역 테이블

<br>

## 참고 자료
- https://www.erdcloud.com/d/uykGfNjFfDtZDvzpk

<img src="https://user-images.githubusercontent.com/59248326/212026299-8558e6c1-6d5e-4ec8-aab0-0cf15a381143.png" width="100%" />

