### PR TITLE
회원 수정, 삭제 기능을 개발한다

### DIFF
--- a/src/main/java/alex/toy/nmj/member/application/MemberService.java
+++ b/src/main/java/alex/toy/nmj/member/application/MemberService.java
@@ -1,9 +1,11 @@
 package alex.toy.nmj.member.application;
 
 import alex.toy.nmj.member.application.command.MemberCreateRequest;
+import alex.toy.nmj.member.application.command.MemberUpdateRequest;
 import alex.toy.nmj.member.domain.Member;
 import alex.toy.nmj.member.domain.MemberRepository;
 import alex.toy.nmj.member.exception.DuplicatedMemberEmailException;
+import alex.toy.nmj.member.exception.MemberNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,7 +20,7 @@ public class MemberService {
     }
 
     @Transactional
-    public Member saveMember(final MemberCreateRequest memberCreateRequest) {
+    public Member save(final MemberCreateRequest memberCreateRequest) {
         Member member = memberCreateRequest.toEntity();
 
         if (isAlreadyExistEmail(member)) {
@@ -26,6 +28,27 @@ public class MemberService {
         }
 
         return memberRepository.save(member);
+    }
+
+    public Member update(final Long memberId, final MemberUpdateRequest memberUpdateRequest) {
+        Member member = findMemberById(memberId);
+
+        if (isUnmodifiableMemberStatus(member)) {
+            throw new MemberNotFoundException();
+        }
+
+        member.update(memberUpdateRequest.toEntity());
+
+        return member;
+    }
+
+    private boolean isUnmodifiableMemberStatus(Member member) {
+        return member.isWaitingJoin() || member.isDeleted();
+    }
+
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
     }
 
     private boolean isAlreadyExistEmail(final Member member) {

--- a/src/main/java/alex/toy/nmj/member/application/MemberService.java
+++ b/src/main/java/alex/toy/nmj/member/application/MemberService.java
@@ -30,6 +30,7 @@ public class MemberService {
         return memberRepository.save(member);
     }
 
+    @Transactional
     public Member update(final Long memberId, final MemberUpdateRequest memberUpdateRequest) {
         Member member = findMemberById(memberId);
 
@@ -42,6 +43,7 @@ public class MemberService {
         return member;
     }
 
+    @Transactional
     public void delete(final Long memberId) {
         Member member = findMemberById(memberId);
 

--- a/src/main/java/alex/toy/nmj/member/application/MemberService.java
+++ b/src/main/java/alex/toy/nmj/member/application/MemberService.java
@@ -42,8 +42,14 @@ public class MemberService {
         return member;
     }
 
-    private boolean isUnmodifiableMemberStatus(Member member) {
-        return member.isWaitingJoin() || member.isDeleted();
+    public void delete(final Long memberId) {
+        Member member = findMemberById(memberId);
+
+        if (isUndeletableMemberStatus(member)) {
+            throw new MemberNotFoundException();
+        }
+
+        member.delete();
     }
 
     private Member findMemberById(Long memberId) {
@@ -53,5 +59,13 @@ public class MemberService {
 
     private boolean isAlreadyExistEmail(final Member member) {
         return memberRepository.existsByEmail(member.getEmail());
+    }
+
+    private boolean isUnmodifiableMemberStatus(Member member) {
+        return member.isWaitingJoin() || member.isDeleted();
+    }
+
+    private boolean isUndeletableMemberStatus(Member member) {
+        return member.isWaitingJoin() || member.isDeleted();
     }
 }

--- a/src/main/java/alex/toy/nmj/member/application/command/MemberUpdateRequest.java
+++ b/src/main/java/alex/toy/nmj/member/application/command/MemberUpdateRequest.java
@@ -1,0 +1,14 @@
+package alex.toy.nmj.member.application.command;
+
+import alex.toy.nmj.member.domain.Member;
+
+public interface MemberUpdateRequest {
+
+    String getPassword();
+
+    String getName();
+
+    String getPhone();
+
+    Member toEntity();
+}

--- a/src/main/java/alex/toy/nmj/member/domain/Member.java
+++ b/src/main/java/alex/toy/nmj/member/domain/Member.java
@@ -85,6 +85,10 @@ public class Member extends BaseEntity {
         updatePhone(member.getPhone());
     }
 
+    public void delete() {
+        this.status = MemberStatus.DELETED;
+    }
+
     private void updatePassword(final String password) {
         if (password != null && !password.isBlank()) {
             this.password = password;

--- a/src/main/java/alex/toy/nmj/member/domain/Member.java
+++ b/src/main/java/alex/toy/nmj/member/domain/Member.java
@@ -11,7 +11,6 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
-
 import java.util.Objects;
 
 import static javax.persistence.EnumType.STRING;
@@ -49,16 +48,15 @@ public class Member extends BaseEntity {
     private MemberStatus status;
 
     @Builder
-    private Member(final Long id, final String email, final String password, final String name,
-                   final String phone, final MemberType type, final MemberStatus status) {
-
+    private Member(final Long id, final String email, final String password,
+                   final String name, final String phone, final MemberType type) {
         this.id = id;
         this.email = email;
         this.password = password;
         this.name = name;
         this.phone = phone;
         this.type = type;
-        changeStatus();
+        createStatus();
     }
 
     public boolean isUser() {
@@ -73,7 +71,39 @@ public class Member extends BaseEntity {
         return MemberType.ADMIN == this.type;
     }
 
-    private void changeStatus() {
+    public boolean isWaitingJoin() {
+        return MemberStatus.WAIT == this.status;
+    }
+
+    public boolean isDeleted() {
+        return MemberStatus.DELETED == this.status;
+    }
+
+    public void update(final Member member) {
+        updatePassword(member.getPassword());
+        updateName(member.getName());
+        updatePhone(member.getPhone());
+    }
+
+    private void updatePassword(final String password) {
+        if (password != null && !password.isBlank()) {
+            this.password = password;
+        }
+    }
+
+    private void updateName(final String name) {
+        if (name != null && !name.isBlank()) {
+            this.name = name;
+        }
+    }
+
+    private void updatePhone(final String phone) {
+        if (phone != null && !phone.isBlank()) {
+            this.phone = phone;
+        }
+    }
+
+    private void createStatus() {
         if (isUser()) {
             this.status = MemberStatus.NORMAL;
         }

--- a/src/main/java/alex/toy/nmj/member/domain/MemberRepository.java
+++ b/src/main/java/alex/toy/nmj/member/domain/MemberRepository.java
@@ -1,6 +1,9 @@
 package alex.toy.nmj.member.domain;
 
+import java.util.Optional;
+
 public interface MemberRepository {
     Member save(Member member);
     boolean existsByEmail(String email);
+    Optional<Member> findById(Long memberId);
 }

--- a/src/main/java/alex/toy/nmj/member/exception/MemberNotFoundException.java
+++ b/src/main/java/alex/toy/nmj/member/exception/MemberNotFoundException.java
@@ -1,0 +1,13 @@
+package alex.toy.nmj.member.exception;
+
+/**
+ * 회원을 찾지 못했을 때 던지는 예외입니다. <br>
+ * 기본적으로 RuntimeException을 상속받기에, 예외 발생 시 roll-back을 수행합니다.
+ */
+public class MemberNotFoundException extends RuntimeException {
+    private static final String MESSAGE = "회원이 존재하지 않습니다.";
+
+    public MemberNotFoundException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/alex/toy/nmj/member/presentation/MemberController.java
+++ b/src/main/java/alex/toy/nmj/member/presentation/MemberController.java
@@ -6,6 +6,7 @@ import alex.toy.nmj.member.presentation.dto.request.MemberUpdateRequestDto;
 import alex.toy.nmj.member.presentation.dto.response.MemberCreateResponse;
 import alex.toy.nmj.member.presentation.dto.response.MemberUpdateResponse;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -36,5 +37,11 @@ public class MemberController {
     public MemberUpdateResponse update(@PathVariable final Long memberId,
                                        @RequestBody @Valid final MemberUpdateRequestDto memberUpdateRequestDto) {
         return new MemberUpdateResponse(memberService.update(memberId, memberUpdateRequestDto));
+    }
+
+    @DeleteMapping("/{memberId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable final Long memberId) {
+        memberService.delete(memberId);
     }
 }

--- a/src/main/java/alex/toy/nmj/member/presentation/MemberController.java
+++ b/src/main/java/alex/toy/nmj/member/presentation/MemberController.java
@@ -2,8 +2,12 @@ package alex.toy.nmj.member.presentation;
 
 import alex.toy.nmj.member.application.MemberService;
 import alex.toy.nmj.member.presentation.dto.request.MemberCreateRequestDto;
+import alex.toy.nmj.member.presentation.dto.request.MemberUpdateRequestDto;
 import alex.toy.nmj.member.presentation.dto.response.MemberCreateResponse;
+import alex.toy.nmj.member.presentation.dto.response.MemberUpdateResponse;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +29,12 @@ public class MemberController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public MemberCreateResponse create(@RequestBody @Valid final MemberCreateRequestDto memberCreateRequestDto) {
-        return new MemberCreateResponse(memberService.saveMember(memberCreateRequestDto));
+        return new MemberCreateResponse(memberService.save(memberCreateRequestDto));
+    }
+
+    @PatchMapping("/{memberId}")
+    public MemberUpdateResponse update(@PathVariable final Long memberId,
+                                       @RequestBody @Valid final MemberUpdateRequestDto memberUpdateRequestDto) {
+        return new MemberUpdateResponse(memberService.update(memberId, memberUpdateRequestDto));
     }
 }

--- a/src/main/java/alex/toy/nmj/member/presentation/MemberControllerAdvice.java
+++ b/src/main/java/alex/toy/nmj/member/presentation/MemberControllerAdvice.java
@@ -1,6 +1,8 @@
-package alex.toy.nmj.member.exception;
+package alex.toy.nmj.member.presentation;
 
 import alex.toy.nmj.common.exception.ErrorResponse;
+import alex.toy.nmj.member.exception.DuplicatedMemberEmailException;
+import alex.toy.nmj.member.exception.MemberNotFoundException;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
@@ -13,7 +15,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
  */
 @RestControllerAdvice
 @Order(Ordered.HIGHEST_PRECEDENCE)
-public class MemberExceptionHandler {
+public class MemberControllerAdvice {
 
     /**
      * 회원 이메일이 중복될 때 던지는 예외를 핸들링합니다.
@@ -24,6 +26,18 @@ public class MemberExceptionHandler {
     @ResponseStatus(HttpStatus.CONFLICT)
     @ExceptionHandler(DuplicatedMemberEmailException.class)
     public static ErrorResponse handleUserEmailIsAlreadyExisted(final DuplicatedMemberEmailException exception) {
+        return ErrorResponse.from(exception);
+    }
+
+    /**
+     * 회원을 찾지 못했을 때 던지는 예외를 핸들링합니다.
+     *
+     * @param exception 회원을 찾지 못했을 경우
+     * @return 예외 메세지와 응답 코드를 리턴
+     */
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(MemberNotFoundException.class)
+    public static ErrorResponse handleMemberNotFound(final MemberNotFoundException exception) {
         return ErrorResponse.from(exception);
     }
 }

--- a/src/main/java/alex/toy/nmj/member/presentation/dto/request/MemberCreateRequestDto.java
+++ b/src/main/java/alex/toy/nmj/member/presentation/dto/request/MemberCreateRequestDto.java
@@ -4,13 +4,11 @@ import alex.toy.nmj.member.application.command.MemberCreateRequest;
 import alex.toy.nmj.member.domain.Member;
 import alex.toy.nmj.member.domain.MemberType;
 import lombok.Builder;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import javax.validation.constraints.NotBlank;
 
 @Getter
-@EqualsAndHashCode
 public class MemberCreateRequestDto implements MemberCreateRequest {
 
     @NotBlank(message = "이메일을 입력하세요")

--- a/src/main/java/alex/toy/nmj/member/presentation/dto/request/MemberUpdateRequestDto.java
+++ b/src/main/java/alex/toy/nmj/member/presentation/dto/request/MemberUpdateRequestDto.java
@@ -1,0 +1,31 @@
+package alex.toy.nmj.member.presentation.dto.request;
+
+import alex.toy.nmj.member.application.command.MemberUpdateRequest;
+import alex.toy.nmj.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberUpdateRequestDto implements MemberUpdateRequest {
+
+    private String password;
+
+    private String name;
+
+    private String phone;
+
+    @Builder
+    private MemberUpdateRequestDto(final String password, final String name, final String phone) {
+        this.password = password;
+        this.name = name;
+        this.phone = phone;
+    }
+
+    public Member toEntity() {
+        return Member.builder()
+                .password(this.password) // TODO : 암호화 진행 (시큐리티)
+                .name(this.name)
+                .phone(this.phone)
+                .build();
+    }
+}

--- a/src/main/java/alex/toy/nmj/member/presentation/dto/response/MemberUpdateResponse.java
+++ b/src/main/java/alex/toy/nmj/member/presentation/dto/response/MemberUpdateResponse.java
@@ -1,0 +1,50 @@
+package alex.toy.nmj.member.presentation.dto.response;
+
+import alex.toy.nmj.member.domain.Member;
+import alex.toy.nmj.member.domain.MemberStatus;
+import alex.toy.nmj.member.domain.MemberType;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.time.LocalDateTime;
+
+public class MemberUpdateResponse {
+
+    @JsonIgnore
+    private Member member;
+
+    public MemberUpdateResponse(final Member member) {
+        this.member = member;
+    }
+
+    public Long getId() {
+        return this.member.getId();
+    }
+
+    public String getEmail() {
+        return this.member.getEmail();
+    }
+
+    public String getName() {
+        return this.member.getName();
+    }
+
+    public String getPhone() {
+        return this.member.getPhone();
+    }
+
+    public MemberType getType() {
+        return this.member.getType();
+    }
+
+    public MemberStatus getStatus() {
+        return this.member.getStatus();
+    }
+
+    public LocalDateTime getCreatedDate() {
+        return this.member.getCreatedDate();
+    }
+
+    public LocalDateTime getModifiedDate() {
+        return this.member.getModifiedDate();
+    }
+}

--- a/src/test/java/alex/toy/nmj/domain/MemberTest.java
+++ b/src/test/java/alex/toy/nmj/domain/MemberTest.java
@@ -101,5 +101,20 @@ class MemberTest {
                 assertThat(기존_회원_정보.getPhone()).isEqualTo(변경할_회원_정보.getPhone());
             }
         }
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 회원_정보_삭제_시 {
+
+            private Member 기존_회원_정보 = 일반_회원_gibeom.엔티티_생성();
+
+            @Test
+            @DisplayName("회원 상태값이 DELETED로 수정된다")
+            void it_change_member_status_deleted() throws Exception {
+                기존_회원_정보.delete();
+
+                assertThat(기존_회원_정보.isDeleted()).isTrue();
+            }
+        }
     }
 }

--- a/src/test/java/alex/toy/nmj/domain/MemberTest.java
+++ b/src/test/java/alex/toy/nmj/domain/MemberTest.java
@@ -75,4 +75,31 @@ class MemberTest {
             }
         }
     }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 회원_정보_수정_시 {
+
+        @Nested
+        @DisplayName("변경할 컬럼 값이 주어지면")
+        class Context_with_change_data {
+
+            private Member 기존_회원_정보 = 일반_회원_gibeom.엔티티_생성();
+            private Member 변경할_회원_정보 = Member.builder()
+                    .name("이름 바꿀꺼지롱")
+                    .phone("010-0000-0000")
+                    .build();
+
+            @Test
+            @DisplayName("값이 있는 컬럼만 수정된다")
+            void it_change_not_blank() throws Exception {
+
+                기존_회원_정보.update(변경할_회원_정보);
+
+                assertThat(기존_회원_정보.getPassword()).isEqualTo(기존_회원_정보.getPassword());
+                assertThat(기존_회원_정보.getName()).isEqualTo(변경할_회원_정보.getName());
+                assertThat(기존_회원_정보.getPhone()).isEqualTo(변경할_회원_정보.getPhone());
+            }
+        }
+    }
 }

--- a/src/test/java/alex/toy/nmj/dto/TestMemberUpdateRequestDto.java
+++ b/src/test/java/alex/toy/nmj/dto/TestMemberUpdateRequestDto.java
@@ -1,0 +1,28 @@
+package alex.toy.nmj.dto;
+
+public class TestMemberUpdateRequestDto {
+
+    private String password;
+
+    private String name;
+
+    private String phone;
+
+    public TestMemberUpdateRequestDto(String password, String name, String phone) {
+        this.password = password;
+        this.name = name;
+        this.phone = phone;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+}

--- a/src/test/java/alex/toy/nmj/fixture/MemberFixture.java
+++ b/src/test/java/alex/toy/nmj/fixture/MemberFixture.java
@@ -1,6 +1,7 @@
 package alex.toy.nmj.fixture;
 
 import alex.toy.nmj.dto.TestMemberCreateRequestDto;
+import alex.toy.nmj.dto.TestMemberUpdateRequestDto;
 import alex.toy.nmj.member.domain.Member;
 import alex.toy.nmj.member.domain.MemberType;
 import alex.toy.nmj.member.presentation.dto.request.MemberCreateRequestDto;
@@ -8,6 +9,7 @@ import alex.toy.nmj.member.presentation.dto.request.MemberCreateRequestDto;
 public enum MemberFixture {
     // ----- 정상 값 -----
     일반_회원_gibeom("dev.gibeom@gmail.com", "일반77", "giibeom", "010-7777-7777", "USER"),
+    일반_회원_beom("beom@nmj.com", "오마이갓", "beom", "010-0000-0000", "USER"),
     매장_회원_Alex("kpmyung@gmail.com", "매장486", "Alex", "010-1234-5678", "STORE"),
     관리자_회원_기범("admin@gmail.com", "관리자486", "기범관리자", "010-0707-0707", "ADMIN"),
     회원_타입_소문자("small.type@nmj.com", "이메일공백", "이메일공백", "010-4444-4444", "user"),
@@ -62,6 +64,13 @@ public enum MemberFixture {
                 this.name,
                 this.phone,
                 this.type);
+    }
+
+    public TestMemberUpdateRequestDto 수정_요청_데이터_생성() {
+        return new TestMemberUpdateRequestDto(
+                this.password,
+                this.name,
+                this.phone);
     }
 
     public String 이메일() {

--- a/src/test/java/alex/toy/nmj/presentation/MemberControllerTest.java
+++ b/src/test/java/alex/toy/nmj/presentation/MemberControllerTest.java
@@ -3,6 +3,7 @@ package alex.toy.nmj.presentation;
 import alex.toy.nmj.common.util.JsonUtil;
 import alex.toy.nmj.fixture.MemberFixture;
 import alex.toy.nmj.member.application.MemberService;
+import alex.toy.nmj.member.domain.Member;
 import alex.toy.nmj.member.domain.MemberStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -18,6 +19,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import java.io.IOException;
 
 import static alex.toy.nmj.fixture.MemberFixture.매장_회원_Alex;
+import static alex.toy.nmj.fixture.MemberFixture.일반_회원_beom;
 import static alex.toy.nmj.fixture.MemberFixture.일반_회원_gibeom;
 import static alex.toy.nmj.fixture.MemberFixture.회원_비밀번호_비정상;
 import static alex.toy.nmj.fixture.MemberFixture.회원_이름_비정상;
@@ -27,6 +29,7 @@ import static alex.toy.nmj.fixture.MemberFixture.회원_타입_비정상;
 import static alex.toy.nmj.fixture.MemberFixture.회원_타입_소문자;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -108,7 +111,7 @@ class MemberControllerTest extends PresentationTest {
 
                 @BeforeEach
                 void setUp() {
-                    memberService.saveMember(일반_회원_gibeom.등록_요청_DTO_생성());
+                    memberService.save(일반_회원_gibeom.등록_요청_DTO_생성());
                 }
 
                 @Test
@@ -195,6 +198,41 @@ class MemberControllerTest extends PresentationTest {
 
                     perform.andExpect(status().isBadRequest());
                 }
+            }
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 회원_수정_API는 {
+
+        @Nested
+        @DisplayName("유효한 회원 수정 정보가 주어지면")
+        class Context_with_valid_update_data {
+
+            private Member 기존_회원_정보;
+
+            @BeforeEach
+            void setUp() {
+                기존_회원_정보 = memberService.save(일반_회원_gibeom.등록_요청_DTO_생성());
+            }
+
+            @Test
+            @DisplayName("회원 정보를 수정하고 200 상태 코드와 회원 정보를 리턴한다")
+            void it_returns_member() throws Exception {
+                ResultActions perform = mockMvc.perform(
+                        patch(REQUEST_MEMBER_URL + "/" + 기존_회원_정보.getId())
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(JsonUtil.writeValueAsString(일반_회원_beom.수정_요청_데이터_생성()))
+                );
+
+                perform.andExpect(status().isOk());
+                perform.andExpect(content().string(not(containsString("password"))));
+                perform.andExpect(content().string(containsString(일반_회원_gibeom.이메일())));
+                perform.andExpect(content().string(containsString(일반_회원_beom.이름())));
+                perform.andExpect(content().string(containsString(일반_회원_beom.전화번호())));
+
+                perform.andDo(print());
             }
         }
     }

--- a/src/test/java/alex/toy/nmj/presentation/MemberControllerTest.java
+++ b/src/test/java/alex/toy/nmj/presentation/MemberControllerTest.java
@@ -6,6 +6,7 @@ import alex.toy.nmj.member.application.MemberService;
 import alex.toy.nmj.member.domain.Member;
 import alex.toy.nmj.member.domain.MemberStatus;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -53,7 +54,7 @@ class MemberControllerTest extends PresentationTest {
             @DisplayName("회원 상태를 일반으로 저장하고 201 상태 코드와 회원 정보를 리턴한다")
             void it_returns_member() throws Exception {
                 ResultActions perform = mockMvc.perform(
-                        회원_등록_API_수정(일반_회원_gibeom)
+                        회원_등록_API_요청(일반_회원_gibeom)
                 );
 
                 perform.andExpect(status().isCreated());
@@ -73,7 +74,7 @@ class MemberControllerTest extends PresentationTest {
             @DisplayName("회원 상태를 대기로 저장하고 201 상태 코드와 회원 정보를 리턴한다")
             void it_returns_member() throws Exception {
                 ResultActions perform = mockMvc.perform(
-                        회원_등록_API_수정(매장_회원_Alex)
+                        회원_등록_API_요청(매장_회원_Alex)
                 );
 
                 perform.andExpect(status().isCreated());
@@ -93,7 +94,7 @@ class MemberControllerTest extends PresentationTest {
             @DisplayName("201 상태 코드와 회원 정보를 리턴한다")
             void it_returns_member() throws Exception {
                 ResultActions perform = mockMvc.perform(
-                        회원_등록_API_수정(회원_타입_소문자)
+                        회원_등록_API_요청(회원_타입_소문자)
                 );
 
                 perform.andExpect(status().isCreated());
@@ -118,7 +119,7 @@ class MemberControllerTest extends PresentationTest {
                 @DisplayName("409 코드로 응답한다")
                 void it_responses_409() throws Exception {
                     ResultActions perform = mockMvc.perform(
-                            회원_등록_API_수정(일반_회원_gibeom)
+                            회원_등록_API_요청(일반_회원_gibeom)
                     );
 
                     perform.andExpect(status().isConflict());
@@ -133,7 +134,7 @@ class MemberControllerTest extends PresentationTest {
                 @DisplayName("400 코드로 응답한다")
                 void it_responses_400() throws Exception {
                     ResultActions perform = mockMvc.perform(
-                            회원_등록_API_수정(회원_이메일_비정상)
+                            회원_등록_API_요청(회원_이메일_비정상)
                     );
 
                     perform.andExpect(status().isBadRequest());
@@ -148,7 +149,7 @@ class MemberControllerTest extends PresentationTest {
                 @DisplayName("400 코드로 응답한다")
                 void it_responses_400() throws Exception {
                     ResultActions perform = mockMvc.perform(
-                            회원_등록_API_수정(회원_비밀번호_비정상)
+                            회원_등록_API_요청(회원_비밀번호_비정상)
                     );
 
                     perform.andExpect(status().isBadRequest());
@@ -163,7 +164,7 @@ class MemberControllerTest extends PresentationTest {
                 @DisplayName("400 코드로 응답한다")
                 void it_responses_400() throws Exception {
                     ResultActions perform = mockMvc.perform(
-                            회원_등록_API_수정(회원_전화번호_비정상)
+                            회원_등록_API_요청(회원_전화번호_비정상)
                     );
 
                     perform.andExpect(status().isBadRequest());
@@ -178,7 +179,7 @@ class MemberControllerTest extends PresentationTest {
                 @DisplayName("400 코드로 응답한다")
                 void it_responses_400() throws Exception {
                     ResultActions perform = mockMvc.perform(
-                            회원_등록_API_수정(회원_이름_비정상)
+                            회원_등록_API_요청(회원_이름_비정상)
                     );
 
                     perform.andExpect(status().isBadRequest());
@@ -193,7 +194,7 @@ class MemberControllerTest extends PresentationTest {
                 @DisplayName("400 코드로 응답한다")
                 void it_responses_400() throws Exception {
                     ResultActions perform = mockMvc.perform(
-                            회원_등록_API_수정(회원_타입_비정상)
+                            회원_등록_API_요청(회원_타입_비정상)
                     );
 
                     perform.andExpect(status().isBadRequest());
@@ -221,9 +222,7 @@ class MemberControllerTest extends PresentationTest {
             @DisplayName("회원 정보를 수정하고 200 상태 코드와 회원 정보를 리턴한다")
             void it_returns_member() throws Exception {
                 ResultActions perform = mockMvc.perform(
-                        patch(REQUEST_MEMBER_URL + "/" + 기존_회원_정보.getId())
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(JsonUtil.writeValueAsString(일반_회원_beom.수정_요청_데이터_생성()))
+                        회원_수정_API_요청(기존_회원_정보.getId(), 일반_회원_beom)
                 );
 
                 perform.andExpect(status().isOk());
@@ -235,12 +234,80 @@ class MemberControllerTest extends PresentationTest {
                 perform.andDo(print());
             }
         }
+
+        @Nested
+        @DisplayName("찾을 수 없는 회원 id가 주어지면")
+        class Context_with_not_found_member_id {
+
+            @Test
+            @DisplayName("404 코드로 응답한다")
+            void it_responses_404() throws Exception {
+                ResultActions perform = mockMvc.perform(
+                        회원_수정_API_요청(Long.MAX_VALUE, 일반_회원_beom)
+                );
+
+                perform.andExpect(status().isNotFound());
+            }
+        }
+
+        @Nested
+        @DisplayName("회원 상태가 가입 대기일 경우")
+        class Context_with_member_status_wait {
+
+            private Member 매장_가입_대기_회원_정보;
+
+            @BeforeEach
+            void setUp() {
+                매장_가입_대기_회원_정보 = memberService.save(매장_회원_Alex.등록_요청_DTO_생성());
+            }
+
+            @Test
+            @DisplayName("404 코드로 응답한다")
+            void it_responses_404() throws Exception {
+                ResultActions perform = mockMvc.perform(
+                        회원_수정_API_요청(매장_가입_대기_회원_정보.getId(), 일반_회원_beom)
+                );
+
+                perform.andExpect(status().isNotFound());
+            }
+        }
+
+        @Nested
+        @DisplayName("삭제된 회원일 경우")
+        class Context_with_member_status_deleted {
+
+            private Member 삭제된_회원_정보;
+
+            @BeforeEach
+            void setUp() {
+                삭제된_회원_정보 = memberService.save(일반_회원_gibeom.등록_요청_DTO_생성());
+
+                // TODO : delete 메서드
+            }
+
+            @Test
+            @DisplayName("404 코드로 응답한다")
+            @Disabled("삭제 기능 개발 후 disabled 해제 예정")
+            void it_responses_404() throws Exception {
+                ResultActions perform = mockMvc.perform(
+                        회원_수정_API_요청(삭제된_회원_정보.getId(), 일반_회원_beom)
+                );
+
+                perform.andExpect(status().isNotFound());
+            }
+        }
     }
 
-    private static MockHttpServletRequestBuilder 회원_등록_API_수정(MemberFixture memberFixture) throws IOException {
+    private MockHttpServletRequestBuilder 회원_등록_API_요청(MemberFixture memberFixture) throws IOException {
         return post(REQUEST_MEMBER_URL)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(JsonUtil.writeValueAsString(memberFixture.등록_요청_데이터_생성()));
+    }
+
+    private MockHttpServletRequestBuilder 회원_수정_API_요청(Long memberId, MemberFixture memberFixture) throws IOException {
+        return patch(REQUEST_MEMBER_URL + "/" + memberId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(JsonUtil.writeValueAsString(memberFixture.수정_요청_데이터_생성()));
     }
 
     private void Member_이메일_이름_전화번호_회원타입_검증(ResultActions perform, MemberFixture memberFixture) throws Exception {

--- a/src/test/java/alex/toy/nmj/presentation/MemberControllerTest.java
+++ b/src/test/java/alex/toy/nmj/presentation/MemberControllerTest.java
@@ -283,12 +283,11 @@ class MemberControllerTest extends PresentationTest {
             void setUp() {
                 삭제된_회원_정보 = memberService.save(일반_회원_gibeom.등록_요청_DTO_생성());
 
-                // TODO : delete 메서드
+                memberService.delete(삭제된_회원_정보.getId());
             }
 
             @Test
             @DisplayName("404 코드로 응답한다")
-            @Disabled("삭제 기능 개발 후 disabled 해제 예정")
             void it_responses_404() throws Exception {
                 ResultActions perform = mockMvc.perform(
                         회원_수정_API_요청(삭제된_회원_정보.getId(), 일반_회원_beom)

--- a/src/test/java/alex/toy/nmj/presentation/MemberControllerTest.java
+++ b/src/test/java/alex/toy/nmj/presentation/MemberControllerTest.java
@@ -30,6 +30,7 @@ import static alex.toy.nmj.fixture.MemberFixture.회원_타입_비정상;
 import static alex.toy.nmj.fixture.MemberFixture.회원_타입_소문자;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.not;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -294,6 +295,33 @@ class MemberControllerTest extends PresentationTest {
                 );
 
                 perform.andExpect(status().isNotFound());
+            }
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 회원_삭제_API는 {
+
+        @Nested
+        @DisplayName("회원 상태가 정상인 찾을 수 있는 회원 id가 주어지면")
+        class Context_with_valid_member_id {
+
+            private Member 기존_회원_정보;
+
+            @BeforeEach
+            void setUp() {
+                기존_회원_정보 = memberService.save(일반_회원_gibeom.등록_요청_DTO_생성());
+            }
+
+            @Test
+            @DisplayName("204 코드로 응답한다")
+            void it_responses_204() throws Exception {
+                ResultActions perform = mockMvc.perform(
+                        delete(REQUEST_MEMBER_URL + "/" + 기존_회원_정보.getId())
+                );
+
+                perform.andExpect(status().isNoContent());
             }
         }
     }

--- a/src/test/java/alex/toy/nmj/presentation/MemberControllerTest.java
+++ b/src/test/java/alex/toy/nmj/presentation/MemberControllerTest.java
@@ -324,6 +324,67 @@ class MemberControllerTest extends PresentationTest {
                 perform.andExpect(status().isNoContent());
             }
         }
+
+        @Nested
+        @DisplayName("찾을 수 없는 회원 id가 주어지면")
+        class Context_with_not_found_member_id {
+
+            @Test
+            @DisplayName("404 코드로 응답한다")
+            void it_responses_404() throws Exception {
+                ResultActions perform = mockMvc.perform(
+                        delete(REQUEST_MEMBER_URL + "/" + Long.MAX_VALUE)
+                );
+
+                perform.andExpect(status().isNotFound());
+            }
+        }
+
+        @Nested
+        @DisplayName("회원 상태가 가입 대기일 경우")
+        class Context_with_member_status_wait {
+
+            private Member 매장_가입_대기_회원_정보;
+
+            @BeforeEach
+            void setUp() {
+                매장_가입_대기_회원_정보 = memberService.save(매장_회원_Alex.등록_요청_DTO_생성());
+            }
+
+            @Test
+            @DisplayName("404 코드로 응답한다")
+            void it_responses_404() throws Exception {
+                ResultActions perform = mockMvc.perform(
+                        delete(REQUEST_MEMBER_URL + "/" + 매장_가입_대기_회원_정보.getId())
+                );
+
+                perform.andExpect(status().isNotFound());
+            }
+        }
+
+        @Nested
+        @DisplayName("삭제된 회원일 경우")
+        class Context_with_member_status_deleted {
+
+            private Member 삭제된_회원_정보;
+
+            @BeforeEach
+            void setUp() {
+                삭제된_회원_정보 = memberService.save(일반_회원_gibeom.등록_요청_DTO_생성());
+
+                memberService.delete(삭제된_회원_정보.getId());
+            }
+
+            @Test
+            @DisplayName("404 코드로 응답한다")
+            void it_responses_404() throws Exception {
+                ResultActions perform = mockMvc.perform(
+                        delete(REQUEST_MEMBER_URL + "/" + 삭제된_회원_정보.getId())
+                );
+
+                perform.andExpect(status().isNotFound());
+            }
+        }
     }
 
     private MockHttpServletRequestBuilder 회원_등록_API_요청(MemberFixture memberFixture) throws IOException {


### PR DESCRIPTION
## 개요

- #7 

## 작업 요약

- 회원 수정 기능을 개발한다
- 회원 삭제 기능을 개발한다

## 작업 내용

> (체크 박스를 모두 선택해야 merge가 활성화 됩니다.)

- [x] 회원 수정 기능
   - [x] 회원의 비밀번호, 이름, 전화번호만 수정이 가능하다
   - [x] 존재하지 않은 회원이거나, 회원 상태가 가입 대기나 탈퇴일 경우는 수정이 불가하다
- [x] 회원 삭제 기능
   - [x] 실제 데이터를 삭제하지 않고 플래그 값으로 관리한다
   - [x] 존재하지 않은 회원이거나, 회원 상태가 가입 대기나 탈퇴일 경우는 삭제가 불가하다

<br>

## 참고 자료

