### PR TITLE
회원 상세 조회 기능을 개발하고, Javadoc 작업을 진행한다

### DIFF
--- a/src/main/java/alex/toy/nmj/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/alex/toy/nmj/common/exception/GlobalExceptionHandler.java
@@ -13,15 +13,15 @@ import javax.servlet.http.HttpServletRequest;
 
 /**
  * 각 도메인 관련 예외를 제외한 나머지 모든 예외를 핸들링합니다. <br>
- * 각 도메인 ExceptionHandler 보다 핸들링 우선 순위가 낮습니다.
+ * 핸들링 우선 순위가 가장 낮은 값을 갖습니다.
  */
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     /**
-     * `@Valid`가 선언된 RequestDto에서 데이터가 유효하지 않을 때 던지는 예외를 핸들링합니다.
+     * `@Valid`가 선언된 RequestDto에서 유효성 검증 실패 시 던지는 예외를 핸들링합니다.
      *
-     * @param exception `@Valid`가 선언된 RequestDto에서 데이터가 유효하지 않을 때 던지는 예외
+     * @param exception 유효성 검증 실패 시 던지는 예외
      * @return 예외 메세지와 응답 코드를 리턴
      */
     @Override

--- a/src/main/java/alex/toy/nmj/member/application/MemberService.java
+++ b/src/main/java/alex/toy/nmj/member/application/MemberService.java
@@ -19,6 +19,10 @@ public class MemberService {
         this.memberRepository = memberRepository;
     }
 
+    public Member findById(final Long memberId) {
+        return findMemberById(memberId);
+    }
+
     @Transactional
     public Member save(final MemberCreateRequest memberCreateRequest) {
         Member member = memberCreateRequest.toEntity();

--- a/src/main/java/alex/toy/nmj/member/application/MemberService.java
+++ b/src/main/java/alex/toy/nmj/member/application/MemberService.java
@@ -34,7 +34,7 @@ public class MemberService {
     public Member update(final Long memberId, final MemberUpdateRequest memberUpdateRequest) {
         Member member = findMemberById(memberId);
 
-        if (isUnmodifiableMemberStatus(member)) {
+        if (member.isUnmodifiableMemberStatus()) {
             throw new MemberNotFoundException();
         }
 
@@ -47,7 +47,7 @@ public class MemberService {
     public void delete(final Long memberId) {
         Member member = findMemberById(memberId);
 
-        if (isUndeletableMemberStatus(member)) {
+        if (member.isUndeletableMemberStatus()) {
             throw new MemberNotFoundException();
         }
 
@@ -61,13 +61,5 @@ public class MemberService {
 
     private boolean isAlreadyExistEmail(final Member member) {
         return memberRepository.existsByEmail(member.getEmail());
-    }
-
-    private boolean isUnmodifiableMemberStatus(Member member) {
-        return member.isWaitingJoin() || member.isDeleted();
-    }
-
-    private boolean isUndeletableMemberStatus(Member member) {
-        return member.isWaitingJoin() || member.isDeleted();
     }
 }

--- a/src/main/java/alex/toy/nmj/member/application/MemberService.java
+++ b/src/main/java/alex/toy/nmj/member/application/MemberService.java
@@ -19,10 +19,22 @@ public class MemberService {
         this.memberRepository = memberRepository;
     }
 
+    /**
+     * 회원 상세 정보를 조회합니다.
+     *
+     * @param memberId 회원 고유 번호
+     * @return 회원 상세 정보
+     */
     public Member findById(final Long memberId) {
         return findMemberById(memberId);
     }
 
+    /**
+     * 회원 정보를 등록합니다.
+     *
+     * @param memberCreateRequest 등록할 회원 정보
+     * @return 등록한 회원 정보
+     */
     @Transactional
     public Member save(final MemberCreateRequest memberCreateRequest) {
         Member member = memberCreateRequest.toEntity();
@@ -34,6 +46,13 @@ public class MemberService {
         return memberRepository.save(member);
     }
 
+    /**
+     * 회원 정보를 수정합니다.
+     *
+     * @param memberId            수정할 회원 고유 번호
+     * @param memberUpdateRequest 수정할 회원 정보
+     * @return 수정한 회원 정보
+     */
     @Transactional
     public Member update(final Long memberId, final MemberUpdateRequest memberUpdateRequest) {
         Member member = findMemberById(memberId);
@@ -47,6 +66,11 @@ public class MemberService {
         return member;
     }
 
+    /**
+     * 회원 정보를 삭제합니다.
+     *
+     * @param memberId 삭제할 회원 고유 번호
+     */
     @Transactional
     public void delete(final Long memberId) {
         Member member = findMemberById(memberId);
@@ -57,6 +81,7 @@ public class MemberService {
 
         member.delete();
     }
+
 
     private Member findMemberById(Long memberId) {
         return memberRepository.findById(memberId)

--- a/src/main/java/alex/toy/nmj/member/domain/Member.java
+++ b/src/main/java/alex/toy/nmj/member/domain/Member.java
@@ -79,6 +79,14 @@ public class Member extends BaseEntity {
         return MemberStatus.DELETED == this.status;
     }
 
+    public boolean isUnmodifiableMemberStatus() {
+        return this.isWaitingJoin() || this.isDeleted();
+    }
+
+    public boolean isUndeletableMemberStatus() {
+        return this.isWaitingJoin() || this.isDeleted();
+    }
+
     public void update(final Member member) {
         updatePassword(member.getPassword());
         updateName(member.getName());

--- a/src/main/java/alex/toy/nmj/member/domain/Member.java
+++ b/src/main/java/alex/toy/nmj/member/domain/Member.java
@@ -59,43 +59,87 @@ public class Member extends BaseEntity {
         createStatus();
     }
 
+    /**
+     * 회원 타입이 일반 회원인지 확인합니다.
+     * 
+     * @return 일반 회원 여부
+     */
     public boolean isUser() {
         return MemberType.USER == this.type;
     }
 
+    /**
+     * 회원 타입이 매장 회원인지 확입합니다.
+     * 
+     * @return 매장 회원 여부
+     */
     public boolean isStore() {
         return MemberType.STORE == this.type;
     }
 
+    /**
+     * 회원 타입이 관리자 회원인지 확인합니다.
+     * 
+     * @return 관리자 회원 여부
+     */
     public boolean isAdmin() {
         return MemberType.ADMIN == this.type;
     }
 
+    /**
+     * 회원 상태가 가입 대기 상태인지 확인합니다.
+     * 
+     * @return 가입 대기 상태 여부
+     */
     public boolean isWaitingJoin() {
         return MemberStatus.WAIT == this.status;
     }
 
+    /**
+     * 회원 상태가 삭제된 상태인지 확인합니다.
+     * 
+     * @return 삭제 상태 여부
+     */
     public boolean isDeleted() {
         return MemberStatus.DELETED == this.status;
     }
 
+    /**
+     * 회원 상태가 수정 가능한 상태인지 확인합니다.
+     *
+     * @return 수정 가능 여부
+     */
     public boolean isUnmodifiableMemberStatus() {
         return this.isWaitingJoin() || this.isDeleted();
     }
 
+    /**
+     * 회원 상태가 삭제 가능한 상태인지 확인합니다.
+     *
+     * @return 삭제 가능 여부
+     */
     public boolean isUndeletableMemberStatus() {
         return this.isWaitingJoin() || this.isDeleted();
     }
 
+    /**
+     * 회원 정보를 수정합니다.
+     *
+     * @param member 수정할 회원 정보
+     */
     public void update(final Member member) {
         updatePassword(member.getPassword());
         updateName(member.getName());
         updatePhone(member.getPhone());
     }
 
+    /**
+     * 회원 정보를 삭제 처리 합니다.
+     */
     public void delete() {
         this.status = MemberStatus.DELETED;
     }
+
 
     private void updatePassword(final String password) {
         if (password != null && !password.isBlank()) {
@@ -118,10 +162,12 @@ public class Member extends BaseEntity {
     private void createStatus() {
         if (isUser()) {
             this.status = MemberStatus.NORMAL;
+            return;
         }
 
         if (isStore()) {
             this.status = MemberStatus.WAIT;
+            return;
         }
 
         if (isAdmin()) {

--- a/src/main/java/alex/toy/nmj/member/domain/Member.java
+++ b/src/main/java/alex/toy/nmj/member/domain/Member.java
@@ -27,7 +27,7 @@ public class Member extends BaseEntity {
     @Column(name = "member_id")
     private Long id;
 
-    @Column(unique = true, nullable = false, length = 100)
+    @Column(nullable = false, length = 100)
     private String email;
 
     @Column(nullable = false, length = 70)

--- a/src/main/java/alex/toy/nmj/member/exception/DuplicatedMemberEmailException.java
+++ b/src/main/java/alex/toy/nmj/member/exception/DuplicatedMemberEmailException.java
@@ -2,7 +2,7 @@ package alex.toy.nmj.member.exception;
 
 /**
  * 회원의 이메일이 중복될 때 던지는 예외입니다. <br>
- * 기본적으로 RuntimeException을 상속받기에, 예외 발생 시 roll-back을 수행합니다.
+ * RuntimeException을 상속받으므로 예외 발생 시 roll-back을 수행합니다.
  */
 public class DuplicatedMemberEmailException extends RuntimeException {
     private static final String MESSAGE = "회원의 아이디가 중복됩니다.";

--- a/src/main/java/alex/toy/nmj/member/exception/InvalidMemberTypeException.java
+++ b/src/main/java/alex/toy/nmj/member/exception/InvalidMemberTypeException.java
@@ -1,5 +1,9 @@
 package alex.toy.nmj.member.exception;
 
+/**
+ * 회원 타입이 유효하지 않을 때 던지는 예외입니다. <br>
+ * RuntimeException을 상속받으므로 예외 발생 시 roll-back을 수행합니다.
+ */
 public class InvalidMemberTypeException extends RuntimeException {
     private static final String MESSAGE = "회원 타입이 유효하지 않습니다.";
 

--- a/src/main/java/alex/toy/nmj/member/exception/MemberNotFoundException.java
+++ b/src/main/java/alex/toy/nmj/member/exception/MemberNotFoundException.java
@@ -2,7 +2,7 @@ package alex.toy.nmj.member.exception;
 
 /**
  * 회원을 찾지 못했을 때 던지는 예외입니다. <br>
- * 기본적으로 RuntimeException을 상속받기에, 예외 발생 시 roll-back을 수행합니다.
+ * RuntimeException을 상속받으므로 예외 발생 시 roll-back을 수행합니다.
  */
 public class MemberNotFoundException extends RuntimeException {
     private static final String MESSAGE = "회원이 존재하지 않습니다.";

--- a/src/main/java/alex/toy/nmj/member/presentation/MemberController.java
+++ b/src/main/java/alex/toy/nmj/member/presentation/MemberController.java
@@ -4,9 +4,11 @@ import alex.toy.nmj.member.application.MemberService;
 import alex.toy.nmj.member.presentation.dto.request.MemberCreateRequestDto;
 import alex.toy.nmj.member.presentation.dto.request.MemberUpdateRequestDto;
 import alex.toy.nmj.member.presentation.dto.response.MemberCreateResponse;
+import alex.toy.nmj.member.presentation.dto.response.MemberResponse;
 import alex.toy.nmj.member.presentation.dto.response.MemberUpdateResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,5 +45,10 @@ public class MemberController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable final Long memberId) {
         memberService.delete(memberId);
+    }
+
+    @GetMapping("/{memberId}")
+    public MemberResponse detail(@PathVariable final Long memberId) {
+        return new MemberResponse(memberService.findById(memberId));
     }
 }

--- a/src/main/java/alex/toy/nmj/member/presentation/dto/response/MemberResponse.java
+++ b/src/main/java/alex/toy/nmj/member/presentation/dto/response/MemberResponse.java
@@ -1,0 +1,50 @@
+package alex.toy.nmj.member.presentation.dto.response;
+
+import alex.toy.nmj.member.domain.Member;
+import alex.toy.nmj.member.domain.MemberStatus;
+import alex.toy.nmj.member.domain.MemberType;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import java.time.LocalDateTime;
+
+public class MemberResponse {
+
+    @JsonIgnore
+    private Member member;
+
+    public MemberResponse(final Member member) {
+        this.member = member;
+    }
+
+    public Long getId() {
+        return this.member.getId();
+    }
+
+    public String getEmail() {
+        return this.member.getEmail();
+    }
+
+    public String getName() {
+        return this.member.getName();
+    }
+
+    public String getPhone() {
+        return this.member.getPhone();
+    }
+
+    public MemberType getType() {
+        return this.member.getType();
+    }
+
+    public MemberStatus getStatus() {
+        return this.member.getStatus();
+    }
+
+    public LocalDateTime getCreatedDate() {
+        return this.member.getCreatedDate();
+    }
+
+    public LocalDateTime getModifiedDate() {
+        return this.member.getModifiedDate();
+    }
+}


### PR DESCRIPTION
## 개요

- close: #7 

## 작업 요약

- 회원 상세 조회 기능을 개발한다
- 회원 도메인 관련 모든 public 메서드에 Javadoc을 작성한다

## 작업 내용

> (체크 박스를 모두 선택해야 merge가 활성화 됩니다.)

- [x]  회원 상세 조회 기능
   - [x]  비밀번호를 제외한 회원의 상세 정보를 조회한다
   - [x] 존재하지 않은 회원일 경우는 조회가 불가하다
- [x] 회원 도메인 Javadoc 작업

<br>

## 참고 자료

- https://johngrib.github.io/wiki/java/javadoc/
